### PR TITLE
make shift non-destructive on a

### DIFF
--- a/bn.c
+++ b/bn.c
@@ -545,14 +545,14 @@ void bignum_isqrt(struct bn *a, struct bn* b)
   require(a, "a is null");
   require(b, "b is null");
 
-  struct bn high, mid, tmp;
+  struct bn low, high, mid, tmp;
 
-  bignum_init(b);
+  bignum_init(&low);
   bignum_assign(&high, a);
   bignum_rshift(&high, &mid, 1);
   bignum_inc(&mid);
 
-  while (bignum_cmp(&high, b) > 0) 
+  while (bignum_cmp(&high, &low) > 0) 
   {
     bignum_mul(&mid, &mid, &tmp);
     if (bignum_cmp(&tmp, a) > 0) 
@@ -562,13 +562,14 @@ void bignum_isqrt(struct bn *a, struct bn* b)
     }
     else 
     {
-      bignum_assign(b, &mid);
+      bignum_assign(&low, &mid);
     }
-    bignum_sub(&high,b,&mid);
+    bignum_sub(&high,&low,&mid);
     _rshift_one_bit(&mid);
-    bignum_add(b,&mid,&mid);
+    bignum_add(&low,&mid,&mid);
     bignum_inc(&mid);
   }
+  bignum_assign(b,&low);
 }
 
 

--- a/bn.c
+++ b/bn.c
@@ -379,6 +379,23 @@ void bignum_rshift(struct bn* a, struct bn* b, int nbits)
 void bignum_mod(struct bn* a, struct bn* b, struct bn* c)
 {
   /*
+    Take divmod and throw away div part
+  */
+  require(a, "a is null");
+  require(b, "b is null");
+  require(c, "c is null");
+
+  struct bn tmp;
+
+  bignum_divmod(a,b,&tmp,c);
+}
+
+void bignum_divmod(struct bn* a, struct bn* b, struct bn* c, struct bn* d)
+{
+  /*
+    Puts a%b in d
+    and a/b in c
+
     mod(a,b) = a - ((a / b) * b)
 
     example:
@@ -397,7 +414,7 @@ void bignum_mod(struct bn* a, struct bn* b, struct bn* c)
   bignum_mul(c, b, &tmp);
 
   /* c = a - tmp */
-  bignum_sub(a, &tmp, c);
+  bignum_sub(a, &tmp, d);
 }
 
 

--- a/bn.c
+++ b/bn.c
@@ -325,12 +325,13 @@ void bignum_lshift(struct bn* a, struct bn* b, int nbits)
   require(b, "b is null");
   require(nbits >= 0, "no negative shifts");
 
+  bignum_assign(b, a);
   /* Handle shift in multiples of word-size */
   const int nbits_pr_word = (WORD_SIZE * 8);
   int nwords = nbits / nbits_pr_word;
   if (nwords != 0)
   {
-    _lshift_word(a, nwords);
+    _lshift_word(b, nwords);
     nbits -= (nwords * nbits_pr_word);
   }
 
@@ -339,11 +340,10 @@ void bignum_lshift(struct bn* a, struct bn* b, int nbits)
     int i;
     for (i = (BN_ARRAY_SIZE - 1); i > 0; --i)
     {
-      a->array[i] = (a->array[i] << nbits) | (a->array[i - 1] >> ((8 * WORD_SIZE) - nbits));
+      b->array[i] = (b->array[i] << nbits) | (b->array[i - 1] >> ((8 * WORD_SIZE) - nbits));
     }
-    a->array[i] <<= nbits;
+    b->array[i] <<= nbits;
   }
-  bignum_assign(b, a);
 }
 
 
@@ -352,13 +352,14 @@ void bignum_rshift(struct bn* a, struct bn* b, int nbits)
   require(a, "a is null");
   require(b, "b is null");
   require(nbits >= 0, "no negative shifts");
-
+  
+  bignum_assign(b, a);
   /* Handle shift in multiples of word-size */
   const int nbits_pr_word = (WORD_SIZE * 8);
   int nwords = nbits / nbits_pr_word;
   if (nwords != 0)
   {
-    _rshift_word(a, nwords);
+    _rshift_word(b, nwords);
     nbits -= (nwords * nbits_pr_word);
   }
 
@@ -367,11 +368,11 @@ void bignum_rshift(struct bn* a, struct bn* b, int nbits)
     int i;
     for (i = 0; i < (BN_ARRAY_SIZE - 1); ++i)
     {
-      a->array[i] = (a->array[i] >> nbits) | (a->array[i + 1] << ((8 * WORD_SIZE) - nbits));
+      b->array[i] = (b->array[i] >> nbits) | (b->array[i + 1] << ((8 * WORD_SIZE) - nbits));
     }
-    a->array[i] >>= nbits;
+    b->array[i] >>= nbits;
   }
-  bignum_assign(b, a);
+  
 }
 
 

--- a/bn.c
+++ b/bn.c
@@ -540,6 +540,37 @@ void bignum_pow(struct bn* a, struct bn* b, struct bn* c)
   }
 }
 
+void bignum_isqrt(struct bn *a, struct bn* b)
+{
+  require(a, "a is null");
+  require(b, "b is null");
+
+  struct bn high, mid, tmp;
+
+  bignum_init(b);
+  bignum_assign(&high, a);
+  bignum_rshift(&high, &mid, 1);
+  bignum_inc(&mid);
+
+  while (bignum_cmp(&high, b) > 0) 
+  {
+    bignum_mul(&mid, &mid, &tmp);
+    if (bignum_cmp(&tmp, a) > 0) 
+    {
+      bignum_assign(&high, &mid);
+      bignum_dec(&high);
+    }
+    else 
+    {
+      bignum_assign(b, &mid);
+    }
+    bignum_sub(&high,b,&mid);
+    _rshift_one_bit(&mid);
+    bignum_add(b,&mid,&mid);
+    bignum_inc(&mid);
+  }
+}
+
 
 void bignum_assign(struct bn* dst, struct bn* src)
 {

--- a/bn.h
+++ b/bn.h
@@ -99,6 +99,7 @@ void bignum_sub(struct bn* a, struct bn* b, struct bn* c); /* c = a - b */
 void bignum_mul(struct bn* a, struct bn* b, struct bn* c); /* c = a * b */
 void bignum_div(struct bn* a, struct bn* b, struct bn* c); /* c = a / b */
 void bignum_mod(struct bn* a, struct bn* b, struct bn* c); /* c = a % b */
+void bignum_divmod(struct bn* a, struct bn* b, struct bn* c, struct bn* d); /* c = a/b, d = a%b */
 
 /* Bitwise operations: */
 void bignum_and(struct bn* a, struct bn* b, struct bn* c); /* c = a & b */

--- a/bn.h
+++ b/bn.h
@@ -114,6 +114,7 @@ int  bignum_is_zero(struct bn* n);                         /* For comparison wit
 void bignum_inc(struct bn* n);                             /* Increment: add one to n */
 void bignum_dec(struct bn* n);                             /* Decrement: subtract one from n */
 void bignum_pow(struct bn* a, struct bn* b, struct bn* c); /* Calculate a^b -- e.g. 2^10 => 1024 */
+void bignum_isqrt(struct bn* a, struct bn* b);             /* Integer square root -- e.g. isqrt(5) => 2*/
 void bignum_assign(struct bn* dst, struct bn* src);        /* Copy src into dst -- dst := src */
 
 

--- a/scripts/isqrt.py
+++ b/scripts/isqrt.py
@@ -1,0 +1,25 @@
+#isqrt.py
+
+import math
+
+def isqrt(n):
+	if n == 0: return 0
+	high = n
+	low = 0
+	calcMid = lambda: (high - low) / 2 + low + 1
+	mid = calcMid()
+	while high > low:
+		sq = mid**2
+		if sq > n:
+			high = mid - 1
+		else:
+			low = mid
+		mid = calcMid()
+	return low
+
+if __name__ == "__main__":
+	for i in range(10000000):
+		sq = isqrt(i)
+		if sq != int(math.sqrt(i)):
+			print "Failed on {}: {}".format(i, sq)
+		elif i % 100000==0: print i 

--- a/scripts/test_rand.py
+++ b/scripts/test_rand.py
@@ -16,6 +16,7 @@ from random import Random, choice
 import subprocess
 import sys
 import os
+import math
 
 
 TEST_BINARY = "./build/test_random"
@@ -48,7 +49,8 @@ POW = 7
 MOD = 8
 RSHIFT = 9
 LSHIFT = 10
-NUM_OPERATIONS = 11 # this variable should be 1 larger than the last supported operation ^^
+ISQRT = 11
+NUM_OPERATIONS = 12 # this variable should be 1 larger than the last supported operation ^^
 
 # Instantiate object of Random-class for choosing an operand and two operators
 rand = Random()
@@ -117,6 +119,8 @@ while i < NTESTS:
     expected = oper1 << oper2
   elif operation == RSHIFT:
     expected = oper1 >> oper2
+  elif operation == ISQRT:
+		expected = int(math.sqrt(oper1));
 
 
   # Convert to string to pass to C program

--- a/tests/randomized.c
+++ b/tests/randomized.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include "bn.h"
 
-enum { ADD, SUB, MUL, DIV, AND, OR, XOR, POW, MOD, RSHFT, LSHFT };
+enum { ADD, SUB, MUL, DIV, AND, OR, XOR, POW, MOD, RSHFT, LSHFT, ISQRT };
 
 int main(int argc, char** argv)
 {
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
     case XOR:   bignum_xor(&a, &b, &res);   break;
     case POW:   bignum_pow(&a, &b, &res);   break;
     case MOD:   bignum_mod(&a, &b, &res);   break;
-
+    case ISQRT: bignum_isqrt(&a, &res);     break;
     case RSHFT:
     {
       bignum_rshift(&a, &res, bignum_to_int(&b));
@@ -61,6 +61,7 @@ int main(int argc, char** argv)
     {
       bignum_lshift(&a, &res, bignum_to_int(&b));
     } break;
+    
 
     default:
       printf("default switch-case hit: unknown operator '%d' \n", oper);
@@ -81,7 +82,7 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  //assert(bignum_cmp(&a_before, &a) == EQUAL);
+  assert(bignum_cmp(&a_before, &a) == EQUAL);
   assert(bignum_cmp(&b_before, &b) == EQUAL);
 
   return 0;


### PR DESCRIPTION
Shift operations mutated the input number a. Acording to the spec they shouldn't, and now they don't. At no additional computational penalty.