### PR TITLE
Fix _rshift with big nwords

### DIFF
--- a/bn.c
+++ b/bn.c
@@ -594,10 +594,23 @@ static void _rshift_word(struct bn* a, int nwords)
   require(nwords >= 0, "no negative shifts");
 
   int i;
-  for (i = 0; i < nwords; ++i)
+
+
+  if (nwords >= BN_ARRAY_SIZE)
   {
-    a->array[i] = a->array[i + 1];
+    for (i = 0; i < BN_ARRAY_SIZE; ++i)
+    {
+      a->array[i] = 0;
+    }
+    return;
   }
+
+
+  for (i = 0; i < BN_ARRAY_SIZE - nwords; ++i)
+  {
+    a->array[i] = a->array[i + nwords];
+  }
+
   for (; i < BN_ARRAY_SIZE; ++i)
   {
     a->array[i] = 0;


### PR DESCRIPTION
It seems the `_rshift_word` function does not correctly handles the case where `nwords` is bigger than 1. This imply `bignum_rshift` doesn't handle shifts greater than 64 bits. Here is a test case (not included in the pr)

```C
#include <stdio.h>
#include "bn.h"

int main()
{
  struct bn n1, n2;
  char buf[8192];

  bignum_from_string(&n1, "11112222333344445555666677778888", 32);
  bignum_rshift(&n1, &n2, 64);

  bignum_to_string(&n2, buf, sizeof(buf));
  printf("m = %s \n", buf);

  return 0;


}

```