### PR TITLE
Zero string output

### DIFF
--- a/bn.c
+++ b/bn.c
@@ -160,10 +160,9 @@ void bignum_to_string(struct bn* n, char* str, int nbytes)
     {
       str[i] = str[i + j];
     }
+    /* Zero-terminate string */
+    str[i] = 0;
   }
-  
-  /* Zero-terminate string */
-  str[i] = 0;
 }
 
 

--- a/bn.c
+++ b/bn.c
@@ -147,12 +147,21 @@ void bignum_to_string(struct bn* n, char* str, int nbytes)
     j += 1;
   }
  
-  /* Move string j places ahead, effectively skipping leading zeros */ 
-  for (i = 0; i < (nbytes - j); ++i)
+  /* Detect whether bignum is zero or not */
+  if (j == 2*BIG_NUM_BYTES)
   {
-    str[i] = str[i + j];
+    str[0] = '0';
+    str[1] = 0;
   }
-
+  else
+  {
+    /* Move string j places ahead, effectively skipping leading zeros */ 
+    for (i = 0; i < (nbytes - j); ++i)
+    {
+      str[i] = str[i + j];
+    }
+  }
+  
   /* Zero-terminate string */
   str[i] = 0;
 }

--- a/bn.h
+++ b/bn.h
@@ -29,8 +29,12 @@ There may well be room for performance-optimizations and improvements.
   #define WORD_SIZE 4
 #endif
 
+#ifndef BIG_NUM_BYTES
+  #define BIG_NUM_BYTES 128 
+#endif
+
 /* Size of big-numbers in bytes */
-#define BN_ARRAY_SIZE    (128 / WORD_SIZE)
+#define BN_ARRAY_SIZE    (BIG_NUM_BYTES / WORD_SIZE)
 
 
 /* Here comes the compile-time specialization for how large the underlying array size should be. */


### PR DESCRIPTION
Modified the string output routine to return '0' string when the given bn was 0.
Current routine return empty string but, in testing the number with string format, '0' string return would be more appropritate (at least for me).

I add a `BIG_NUM_BYTES' macro to be used in the detection code. 
With the macro, the users could complie the library in `-D` option without modifying internal code.
